### PR TITLE
Fix Provider updates from being dropped

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+comment: off
+coverage:
+  status:
+    project: yes
+    patch: no
+    changes: no

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,12 +21,8 @@ export const useSubjectValue = <T, R>(
 
   // This forces an update when the given output hasn't been stored yet
   const [, forceUpdate] = useReducer((x: number, output: R) => {
-    if (output !== state.current.output) {
-      state.current.output = output;
-      return x + 1;
-    } else {
-      return x;
-    }
+    state.current.output = output;
+    return x + 1;
   }, 0);
 
   const [update, unsubscribe] = useMemo<Internals<T>>(() => {


### PR DESCRIPTION
It's hard to figure out why this is, but it seems that the reducer is called twice with the same output even though `forceUpdate` is only called once. This only happens when a provider is being updated.

Since the second update is dropped in `useSubjectValue`, React never actually updates the Provider, hence the bug occurs.

I don't quite know why it's necessary for React to run the effect twice, but I'd suspect that it's being run in a second fiber phase that is just responsible for distributing the update somehow. I'd love to know why that is but for now I'm content to know that this fixes the issue.