### PR TITLE
start adapting to concurrent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { useReducer, useRef, useMemo, useEffect, useLayoutEffect } from 'react';
-import { pipe, makeSubject, subscribe, Operator } from 'wonka';
+import { pipe, makeSubject, subscribe, Operator, Source } from 'wonka';
 
 interface State<R, T = R> {
   active: boolean;
@@ -10,7 +10,7 @@ interface State<R, T = R> {
 const useIsomorphicEffect =
   typeof window === 'undefined' ? useEffect : useLayoutEffect;
 
-type Internals<T> = [(input: T) => void, any];
+type Internals<T> = [(input: T) => void, Source<T>];
 
 export const useSubjectValue = <T, R>(
   fn: Operator<T, R>,
@@ -45,7 +45,6 @@ export const useSubjectValue = <T, R>(
   }, []);
 
   useIsomorphicEffect(() => {
-    // @ts-ignore
     const [unsubscribe] = pipe(
       fn(input$),
       subscribe((output: R) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,7 @@ export const useSubjectValue = <T, R>(
   useIsomorphicEffect(() => {
     const [unsubscribe] = pipe(
       fn(input$),
-      subscribe((output: R) => {
-        forceUpdate(output);
-      })
+      subscribe(forceUpdate)
     );
 
     return unsubscribe;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,22 +49,18 @@ export const useSubjectValue = <T, R>(
     const [unsubscribe] = pipe(
       fn(input$),
       subscribe((output: R) => {
-        if (!state.current.active) {
-          forceUpdate(output);
-        } else {
-          // The result of the input stream updates the latest output if it's an immediate result
-          state.current.output = output;
-        }
+        forceUpdate(output);
       })
     );
 
     return unsubscribe;
   }, []);
 
-  // Set active flag to true while updating and call it with new input
-  state.current.active = true;
-  update(input);
-  state.current.active = false;
+  useIsomorphicEffect(() => {
+    state.current.active = true;
+    update(input);
+    state.current.active = false;
+  }, [input]);
 
   return [state.current.output, update];
 };


### PR DESCRIPTION
Trying to get some thoughts on this, if we use `useLayoutEffect` in the browser env it should be synchronous right?

> TODO: test in urql examples